### PR TITLE
fix gui timer cancellation

### DIFF
--- a/ui/TimerCard.qml
+++ b/ui/TimerCard.qml
@@ -101,9 +101,6 @@ ItemDelegate {
                     }
 
                     onClicked: {
-                        if (timerViews.count == 1) {
-                            Mycroft.MycroftController.sendText("cancel all timers")
-                        }
                         triggerGuiEvent("timerskill.gui.stop.timer", {"timer": modelData})
                     }
                 }


### PR DESCRIPTION
the timer cancellation **per gui** didn't work as expected. Always the first timer in the timer list was cancelled due to a call to [_cancel_single_timer()](https://github.com/OpenVoiceOS/skill-ovos-timer/blob/24c38ec3d6744d9fffed9b581d90d62188824310/__init__.py#L534)

Fixes:
- deletes the timer properly
- does away with the "cancel all" workaround (TimerCard.qml) when only one timer is present and should be removed
- pickles properly (so it doesn't  [_load_timers()](https://github.com/OpenVoiceOS/skill-ovos-timer/blob/24c38ec3d6744d9fffed9b581d90d62188824310/__init__.py#L934) on skill reload)
- updates the widget

tested both with unnamed and named timers